### PR TITLE
URLの更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "index.json",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/ridenow-ra/prettier-config-dcp.git"
+    "url": "https://github.com/ridenow-ra/prettier-config-doc.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ridenow-ra/prettier-config-dcp/issues"
+    "url": "https://github.com/ridenow-ra/prettier-config-doc/issues"
   },
-  "homepage": "https://github.com/ridenow-ra/prettier-config-dcp#readme"
+  "homepage": "https://github.com/ridenow-ra/prettier-config-doc#readme"
 }


### PR DESCRIPTION
AmplifyのBuiildが失敗する件で、推測としての対応なのですがSSH接続をHTTPSに変更したくの対応です

Amplifyのログ
https://ap-northeast-1.console.aws.amazon.com/amplify/home?region=ap-northeast-1&code=3a7a86c934b45ce40339#/d3ee4np02437a7/develop/134?step=BUILD

サービスが違うが、CicleCIで似たケースの情報
https://support.circleci.com/hc/ja/articles/360009699913-npm-%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%99%82%E3%81%AB%E3%83%AA%E3%83%A2%E3%83%BC%E3%83%88-git-%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%82%92%E8%AA%AD%E3%81%BF%E5%8F%96%E3%82%8C%E3%81%AA%E3%81%84